### PR TITLE
feat: add loading page component

### DIFF
--- a/apps/cms-app/app/dashboard/loading.tsx
+++ b/apps/cms-app/app/dashboard/loading.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+
+export default function loading() {
+  return (
+    <div className="relative flex min-h-screen flex-col items-center justify-center bg-white">
+      <div className="flex flex-col items-center gap-4">
+        {/* Spinner */}
+        <div className="mb-2 h-16 w-16 animate-spin rounded-full border-2 border-indigo-300 border-t-transparent" />
+
+        {/* Labels */}
+        <p className="text-[11px] tracking-[0.3em] uppercase">
+          CMS DE TESTIMONIOS
+        </p>
+        <p className="text-2xl font-light text-gray-800">Cargando...</p>
+        <p className="text-[10px] tracking-[0.25em] uppercase">
+          SINCRONIZANDO DATOS
+        </p>
+      </div>
+
+      {/* Footer */}
+      <p className="absolute bottom-8 text-[10px] tracking-[0.2em] text-gray-400 uppercase">
+        EDTECH.CMS
+      </p>
+    </div>
+  );
+}

--- a/apps/cms-app/app/dashboard/page.tsx
+++ b/apps/cms-app/app/dashboard/page.tsx
@@ -4,6 +4,7 @@ import { LogoutButton } from '../../shared/components/logout-button';
 
 export default function DashboardPage() {
   const { data: session } = useSession();
+
   return (
     <main>
       <div className="min-h-screen bg-gradient-to-br from-green-50 to-green-100">


### PR DESCRIPTION
This pull request introduces a loading screen for the dashboard in the CMS app. The main change is the addition of a new `loading.tsx` component that displays a spinner and relevant status messages while data is loading.

**Loading screen addition:**

* Added a new `loading.tsx` component to `apps/cms-app/app/dashboard/` that shows a centered spinner, status labels ("Cargando...", "Sincronizando datos"), and a footer ("EDTECH.CMS") during dashboard loading.